### PR TITLE
add command to scrape and serialize to single json file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,6 +2507,7 @@ dependencies = [
 name = "spooderman"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "dotenv",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.98"
 chrono = "0.4.39"
 dotenv = "0.15.0"
 env_logger = "0.11.6"

--- a/src/class_scraper.rs
+++ b/src/class_scraper.rs
@@ -1,12 +1,13 @@
 use rayon::prelude::*;
 use scraper::Selector;
+use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 
 use crate::{
     school_area_scraper::ScrapeError, scraper::fetch_url, text_manipulators::extract_text,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Course {
     pub course_id: String,
     pub course_code: String,
@@ -21,7 +22,7 @@ pub struct Course {
     pub classes: Vec<Class>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Class {
     pub course_id: String,
     pub career: String,
@@ -41,7 +42,7 @@ pub struct Class {
     pub class_notes: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Time {
     pub career: String,
     pub day: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,21 +216,15 @@ fn convert_classes_to_json(courses: &[Course]) -> Vec<serde_json::Value> {
     json_classes
 }
 
-async fn handle_scrape(
-    course_vec: &mut Vec<Course>,
-    start_year: i32,
-) -> Result<(), Box<dyn Error>> {
-    for year in &[2025] {
-        // TODO: Batch the 2024 and 2025 years out since both too big to insert into hasura
-        println!("Handling scrape for year: {year}");
-        let mut all_school_offered_courses_scraper =
-            run_all_school_offered_courses_scraper_job(*year).await;
-        if let Some(all_school_offered_courses_scraper) = &mut all_school_offered_courses_scraper {
-            run_school_courses_page_scraper_job(all_school_offered_courses_scraper).await;
-            let course =
-                run_course_classes_page_scraper_job(all_school_offered_courses_scraper).await;
-            course_vec.extend(course);
-        }
+async fn handle_scrape(course_vec: &mut Vec<Course>, year: i32) -> Result<(), Box<dyn Error>> {
+    // TODO: Batch the 2024 and 2025 years out since both too big to insert into hasura
+    println!("Handling scrape for year: {year}");
+    let mut all_school_offered_courses_scraper =
+        run_all_school_offered_courses_scraper_job(year).await;
+    if let Some(all_school_offered_courses_scraper) = &mut all_school_offered_courses_scraper {
+        run_school_courses_page_scraper_job(all_school_offered_courses_scraper).await;
+        let course = run_course_classes_page_scraper_job(all_school_offered_courses_scraper).await;
+        course_vec.extend(course);
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,17 @@ struct Data {
     all_courses: Vec<Course>,
 }
 
+pub fn sort_by_key_ref<T, B, F>(slice: &mut [T], mut f: F)
+where
+    F: FnMut(&T) -> &B,
+    B: Ord,
+{
+    slice.sort_by(|a, b| f(a).cmp(f(b)))
+}
+
 impl Data {
-    fn new(all_courses: Vec<Course>) -> Self {
+    fn new(mut all_courses: Vec<Course>) -> Self {
+        sort_by_key_ref(&mut all_courses, |course| &course.course_id);
         Self { all_courses }
     }
 


### PR DESCRIPTION
i want to make sure that the changes i've made to the scraper in the big PR https://github.com/devsoc-unsw/spooderman/pull/21 are correct, so this PR lets the old/current scraper perform a scrape for a given year (we'll pick 2024 since that data shouldn't change anymore) and serialize it to a single json (simpler than the 3 json files that hasuragres wants). this PR should be merged **before** https://github.com/devsoc-unsw/spooderman/pull/21.