### PR TITLE
chore(actions): unpin deployment dispatch action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Dispatch deployment
-        uses: devsoc-unsw/deployment-dispatch-action@a115e2ad9226805cd2588dc6fa5b7775991b141a
+        uses: devsoc-unsw/deployment-dispatch-action@main
         with:
           deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
           deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
Unpin `devsoc-unsw/deployment-dispatch-action` in `.github/workflows/docker.yml`.

## Changes
- replace the pinned `deployment-dispatch-action` commit SHA with `devsoc-unsw/deployment-dispatch-action@main`
- keep the rest of the existing deployment-dispatch migration unchanged
- keep the existing `github.token` GHCR auth and renamed dispatcher app credentials

## Context
The action repository currently exposes `main` but does not expose a `v1` tag or `v1` branch, so this PR unpins to `@main`.

## Verification
- `yq eval '.' .github/workflows/docker.yml > /dev/null`
- `rg -n "deployment-dispatch-action@" .github/workflows -S`
