### PR TITLE
Fix Docker image build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,4 @@ ARG HASURAGRES_API_KEY
 
 ENV TIMETABLE_API_URL=https://timetable.unsw.edu.au/year/
 
-RUN cargo r -- scrape_n_batch_insert -release
-
+RUN cargo run --release -- scrape_n_batch_insert --year latest-with-data


### PR DESCRIPTION
## Summary
- fix the Dockerfile to invoke the scraper with valid Cargo CLI syntax
- pass the required `--year latest-with-data` argument to `scrape_n_batch_insert`
- keep the image build aligned with the current CLI contract so the build can reach the GHCR push step

## Verification
- `cargo run -- scrape_n_batch_insert --help`

## Context
The failing Actions job was exiting during `docker build` on `RUN cargo r -- scrape_n_batch_insert -release`. That command passed `-release` to the application instead of Cargo and omitted the required `--year` argument, so the image build failed before any GHCR push could happen.
