### PR TITLE
Fix Docker runtime execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM rust:1.80
+FROM rust:1.80 AS builder
+
 WORKDIR /app
 COPY . .
 
-ARG HASURAGRES_URL
-ARG HASURAGRES_API_KEY
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/spooderman /usr/local/bin/spooderman
+COPY --from=builder /app/sql ./sql
 
 ENV TIMETABLE_API_URL=https://timetable.unsw.edu.au/year/
 
-RUN cargo run --release -- scrape_n_batch_insert --year latest-with-data
+ENTRYPOINT ["spooderman"]
+CMD ["scrape_n_batch_insert", "--year", "latest-with-data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,4 @@ ARG HASURAGRES_API_KEY
 
 ENV TIMETABLE_API_URL=https://timetable.unsw.edu.au/year/
 
-RUN cargo r -- scrape_n_batch_insert -release
-
+RUN cargo run --release -- scrape_n_batch_insert --year latest-with-data


### PR DESCRIPTION
## Summary
- switch the Dockerfile to a multi-stage build so scraping runs when the container starts rather than during `docker build`
- keep the runtime image slim and include the SQL files plus runtime SSL/CA dependencies
- keep the builder image on `rust:1.80`

## Verification
- `git push -u origin fix/docker-build-command`
- `docker build -t spooderman:test .` currently fails because this repository uses Rust 2024 edition and Cargo 1.80 does not support it yet

## Notes
- The Dockerfile no longer depends on `HASURAGRES_URL` or `HASURAGRES_API_KEY` being present at image build time.
- With the builder tag reverted to `rust:1.80`, the image still needs a toolchain update before `docker build` can succeed.
